### PR TITLE
Index idempotent [DEVOPS-134]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/lib/Doctrine/Connection.php
+++ b/lib/Doctrine/Connection.php
@@ -1631,15 +1631,9 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
 
         $generated = implode('_', $parts);
 
-        // If the final length is greater than 64 we need to create an abbreviated fk name
+        // Fix for non-idempotent unique names
         if (strlen(sprintf($format, $generated)) > $maxLength) {
-            $generated = '';
-
-            foreach ($parts as $part) {
-                $generated .= $part[0];
-            }
-
-            $name = $generated;
+            $name = $type . '_' . md5($generated);
         } else {
             $name = $generated;
         }


### PR DESCRIPTION
Updated generation of foreign keys and indexes within Doctrine 1 to be idempotent to allow for safe SQL comparison (as opposed to the random clusterfuck implemented normally)